### PR TITLE
Set node status to be out instead of msg.payload

### DIFF
--- a/hardware/PiGpio/36-rpi-gpio.js
+++ b/hardware/PiGpio/36-rpi-gpio.js
@@ -139,7 +139,7 @@ module.exports = function(RED) {
                 if (RED.settings.verbose) { node.log("out: "+out); }
                 if (node.child !== null) {
                     node.child.stdin.write(out+"\n");
-                    node.status({fill:"green",shape:"dot",text:msg.payload.toString()});
+                    node.status({fill:"green",shape:"dot",text:out.toString()});
                 }
                 else {
                     node.error(RED._("rpi-gpio.errors.pythoncommandnotfound"),msg);


### PR DESCRIPTION
Make this node status act the same as pigpio node following recent change
https://github.com/cymplecy/node-red-nodes/commit/6efe5308886a8f31edd4c12b526d6fe838ce252e

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Make this gpio node status consistent with pigpio node
e.g display the out variable rather than the msg.payload

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
